### PR TITLE
handle panic in (*ptr)nil cases

### DIFF
--- a/value.go
+++ b/value.go
@@ -202,7 +202,12 @@ func (valueSystem *boltValueSystem) valueAsConnector(target *C.struct_BoltValue,
 			handled = true
 			switch v.Kind() {
 			case reflect.Ptr:
-				valueSystem.valueAsConnector(target, reflect.ValueOf(value).Elem().Interface())
+				ptrv := reflect.ValueOf(value)
+				if ptrv.IsNil() {
+					C.BoltValue_format_as_Null(target)
+				} else {
+					valueSystem.valueAsConnector(target, ptrv.Elem().Interface())
+				}
 			case reflect.Slice:
 				valueSystem.listAsValue(target, value)
 			case reflect.Map:


### PR DESCRIPTION
Value translation panics for nil `interface{}`.  
Similar to what's described here: https://golang.org/doc/faq#nil_error

For example, with this combo:
```
var niltime *time.Time
params := M{"props": M{"name": "hello", "bla1": niltime}}
q := `
CREATE (b: Bla $props)
RETURN properties(b)
`
```

You get a `panic: reflect: call of reflect.Value.Interface on zero Value`.

This is a pretty common case when mapping from domain structs to `map[string]interface{}`.