### PR TITLE
type aliases handling, value error propagation

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -93,7 +93,11 @@ func (connection *neo4jConnection) Begin(bookmarks []string, txTimeout time.Dura
 	}
 
 	if len(bookmarks) > 0 {
-		bookmarksValue := connection.valueSystem.valueToConnector(bookmarks)
+		bookmarksValue, err := connection.valueSystem.valueToConnector(bookmarks)
+		if err != nil {
+			errmsg := fmt.Sprintf("unable to set bookmarks for begin message: %v", err)
+			return -1, newError(connection, errmsg)
+		}
 		res := C.BoltConnection_set_begin_bookmarks(connection.cInstance, bookmarksValue)
 		C.BoltValue_destroy(bookmarksValue)
 		if res != C.BOLT_SUCCESS {
@@ -110,7 +114,11 @@ func (connection *neo4jConnection) Begin(bookmarks []string, txTimeout time.Dura
 	}
 
 	if len(txMetadata) > 0 {
-		metadataValue := connection.valueSystem.valueToConnector(txMetadata)
+		metadataValue, err := connection.valueSystem.valueToConnector(txMetadata)
+		if err != nil {
+			errmsg := fmt.Sprintf("unable to set tx metadata for begin message: %v", err)
+			return -1, newError(connection, errmsg)
+		}
 		res := C.BoltConnection_set_begin_tx_metadata(connection.cInstance, metadataValue)
 		C.BoltValue_destroy(metadataValue)
 		if res != C.BOLT_SUCCESS {
@@ -170,13 +178,19 @@ func (connection *neo4jConnection) Run(cypher string, params map[string]interfac
 			return -1, newError(connection, "unable to retrieve reference to cypher statement parameter value")
 		}
 
-		connection.valueSystem.valueAsConnector(boltValue, paramValue)
+		if err := connection.valueSystem.valueAsConnector(boltValue, paramValue); err != nil {
+			return -1, newError(connection, fmt.Sprintf("unable to convert parameter value: %v", err))
+		}
 
 		index++
 	}
 
 	if len(bookmarks) > 0 {
-		bookmarksValue := connection.valueSystem.valueToConnector(bookmarks)
+		bookmarksValue, err := connection.valueSystem.valueToConnector(bookmarks)
+		if err != nil {
+			errmsg := fmt.Sprintf("unable to set bookmarks for run message: %v", err)
+			return -1, newError(connection, errmsg)
+		}
 		res := C.BoltConnection_set_run_bookmarks(connection.cInstance, bookmarksValue)
 		C.BoltValue_destroy(bookmarksValue)
 		if res != C.BOLT_SUCCESS {
@@ -193,7 +207,11 @@ func (connection *neo4jConnection) Run(cypher string, params map[string]interfac
 	}
 
 	if len(txMetadata) > 0 {
-		metadataValue := connection.valueSystem.valueToConnector(txMetadata)
+		metadataValue, err := connection.valueSystem.valueToConnector(txMetadata)
+		if err != nil {
+			errmsg := fmt.Sprintf("unable to set tx metadata for run message: %v", err)
+			return -1, newError(connection, errmsg)
+		}
 		res := C.BoltConnection_set_run_tx_metadata(connection.cInstance, metadataValue)
 		C.BoltValue_destroy(metadataValue)
 		if res != C.BOLT_SUCCESS {

--- a/connection.go
+++ b/connection.go
@@ -95,8 +95,7 @@ func (connection *neo4jConnection) Begin(bookmarks []string, txTimeout time.Dura
 	if len(bookmarks) > 0 {
 		bookmarksValue, err := connection.valueSystem.valueToConnector(bookmarks)
 		if err != nil {
-			errmsg := fmt.Sprintf("unable to set bookmarks for begin message: %v", err)
-			return -1, newError(connection, errmsg)
+			return -1, connection.valueSystem.genericErrorFactory("unable to convert bookmarks to connector value for begin message: %v", err)
 		}
 		res := C.BoltConnection_set_begin_bookmarks(connection.cInstance, bookmarksValue)
 		C.BoltValue_destroy(bookmarksValue)
@@ -116,8 +115,7 @@ func (connection *neo4jConnection) Begin(bookmarks []string, txTimeout time.Dura
 	if len(txMetadata) > 0 {
 		metadataValue, err := connection.valueSystem.valueToConnector(txMetadata)
 		if err != nil {
-			errmsg := fmt.Sprintf("unable to set tx metadata for begin message: %v", err)
-			return -1, newError(connection, errmsg)
+			return -1, connection.valueSystem.genericErrorFactory("unable to convert tx metadata to connector value for begin message: %v", err)
 		}
 		res := C.BoltConnection_set_begin_tx_metadata(connection.cInstance, metadataValue)
 		C.BoltValue_destroy(metadataValue)
@@ -179,7 +177,7 @@ func (connection *neo4jConnection) Run(cypher string, params map[string]interfac
 		}
 
 		if err := connection.valueSystem.valueAsConnector(boltValue, paramValue); err != nil {
-			return -1, newError(connection, fmt.Sprintf("unable to convert parameter value: %v", err))
+			return -1, connection.valueSystem.genericErrorFactory("unable to convert parameter %q to connector value for run message: %v", paramName, err)
 		}
 
 		index++
@@ -188,8 +186,7 @@ func (connection *neo4jConnection) Run(cypher string, params map[string]interfac
 	if len(bookmarks) > 0 {
 		bookmarksValue, err := connection.valueSystem.valueToConnector(bookmarks)
 		if err != nil {
-			errmsg := fmt.Sprintf("unable to set bookmarks for run message: %v", err)
-			return -1, newError(connection, errmsg)
+			return -1, connection.valueSystem.genericErrorFactory("unable to convert bookmarks to connector value for run message: %v", err)
 		}
 		res := C.BoltConnection_set_run_bookmarks(connection.cInstance, bookmarksValue)
 		C.BoltValue_destroy(bookmarksValue)
@@ -209,8 +206,7 @@ func (connection *neo4jConnection) Run(cypher string, params map[string]interfac
 	if len(txMetadata) > 0 {
 		metadataValue, err := connection.valueSystem.valueToConnector(txMetadata)
 		if err != nil {
-			errmsg := fmt.Sprintf("unable to set tx metadata for run message: %v", err)
-			return -1, newError(connection, errmsg)
+			return -1, connection.valueSystem.genericErrorFactory("unable to convert tx metadata to connector value for run message: %v", err)
 		}
 		res := C.BoltConnection_set_run_tx_metadata(connection.cInstance, metadataValue)
 		C.BoltValue_destroy(metadataValue)

--- a/connector.go
+++ b/connector.go
@@ -209,13 +209,13 @@ func NewConnector(uri *url.URL, authToken map[string]interface{}, config *Config
 	userAgentStr := C.CString("Go Driver/1.7")
 	routingContextValue, err := valueSystem.valueToConnector(uri.Query())
 	if err != nil {
-		return nil, err
+		return nil, valueSystem.genericErrorFactory("unable to convert routing context to connector value: %v", err)
 	}
 	hostnameStr, portStr := C.CString(uri.Hostname()), C.CString(uri.Port())
 	address := C.BoltAddress_create(hostnameStr, portStr)
 	authTokenValue, err := valueSystem.valueToConnector(authToken)
 	if err != nil {
-		return nil, err
+		return nil, valueSystem.genericErrorFactory("unable to convert authentication token to connector value: %v", err)
 	}
 
 	key := startupLibrary()

--- a/connector.go
+++ b/connector.go
@@ -207,10 +207,16 @@ func NewConnector(uri *url.URL, authToken map[string]interface{}, config *Config
 	}
 
 	userAgentStr := C.CString("Go Driver/1.7")
-	routingContextValue := valueSystem.valueToConnector(uri.Query())
+	routingContextValue, err := valueSystem.valueToConnector(uri.Query())
+	if err != nil {
+		return nil, err
+	}
 	hostnameStr, portStr := C.CString(uri.Hostname()), C.CString(uri.Port())
 	address := C.BoltAddress_create(hostnameStr, portStr)
-	authTokenValue := valueSystem.valueToConnector(authToken)
+	authTokenValue, err := valueSystem.valueToConnector(authToken)
+	if err != nil {
+		return nil, err
+	}
 
 	key := startupLibrary()
 

--- a/value.go
+++ b/value.go
@@ -148,94 +148,121 @@ func (valueSystem *boltValueSystem) valueAsBytes(value *C.struct_BoltValue) []by
 	return C.GoBytes(unsafe.Pointer(val), C.BoltValue_size(value))
 }
 
-func (valueSystem *boltValueSystem) valueToConnector(value interface{}) *C.struct_BoltValue {
+func (valueSystem *boltValueSystem) valueToConnector(value interface{}) (*C.struct_BoltValue, error) {
 	res := C.BoltValue_create()
-
-	valueSystem.valueAsConnector(res, value)
-
-	return res
+	err := valueSystem.valueAsConnector(res, value)
+	return res, err
 }
 
 func (valueSystem *boltValueSystem) valueAsConnector(target *C.struct_BoltValue, value interface{}) error {
 	if value == nil {
 		C.BoltValue_format_as_Null(target)
-	} else {
-		handled := true
-		switch v := value.(type) {
-		case bool:
-			valueSystem.boolAsValue(target, v)
-		case int8:
-			valueSystem.intAsValue(target, int64(v))
-		case int16:
-			valueSystem.intAsValue(target, int64(v))
-		case int:
-			valueSystem.intAsValue(target, int64(v))
-		case int32:
-			valueSystem.intAsValue(target, int64(v))
-		case int64:
-			valueSystem.intAsValue(target, v)
-		case uint8:
-			valueSystem.intAsValue(target, int64(v))
-		case uint16:
-			valueSystem.intAsValue(target, int64(v))
-		case uint:
-			valueSystem.intAsValue(target, int64(v))
-		case uint32:
-			valueSystem.intAsValue(target, int64(v))
-		case uint64:
-			valueSystem.intAsValue(target, int64(v))
-		case float32:
-			valueSystem.floatAsValue(target, float64(v))
-		case float64:
-			valueSystem.floatAsValue(target, v)
-		case string:
-			valueSystem.stringAsValue(target, v)
-		case []byte:
-			valueSystem.bytesAsValue(target, v)
-		default:
-			handled = false
+		return nil
+	}
+
+	// try basic types
+	basic := true
+	switch bv := value.(type) {
+	case bool:
+		valueSystem.boolAsValue(target, bv)
+	case int:
+		valueSystem.intAsValue(target, int64(bv))
+	case int8:
+		valueSystem.intAsValue(target, int64(bv))
+	case int16:
+		valueSystem.intAsValue(target, int64(bv))
+	case int32:
+		valueSystem.intAsValue(target, int64(bv))
+	case int64:
+		valueSystem.intAsValue(target, bv)
+	case uint:
+		valueSystem.intAsValue(target, int64(bv))
+	case uint8:
+		valueSystem.intAsValue(target, int64(bv))
+	case uint16:
+		valueSystem.intAsValue(target, int64(bv))
+	case uint32:
+		valueSystem.intAsValue(target, int64(bv))
+	case uint64:
+		valueSystem.intAsValue(target, int64(bv))
+	case float32:
+		valueSystem.floatAsValue(target, float64(bv))
+	case float64:
+		valueSystem.floatAsValue(target, bv)
+	case string:
+		valueSystem.stringAsValue(target, bv)
+	case []byte:
+		valueSystem.bytesAsValue(target, bv)
+	default:
+		basic = false
+	}
+	if basic {
+		return nil
+	}
+
+	vtype := reflect.TypeOf(value)
+
+	// try aliased types
+	alias := true
+	switch vtype.Kind() {
+	case reflect.Bool:
+		b := reflect.ValueOf(value).Bool()
+		valueSystem.boolAsValue(target, b)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		i := reflect.ValueOf(value).Int()
+		valueSystem.intAsValue(target, i)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		i := int64(reflect.ValueOf(value).Uint())
+		valueSystem.intAsValue(target, i)
+	case reflect.Float32, reflect.Float64:
+		f := reflect.ValueOf(value).Float()
+		valueSystem.floatAsValue(target, f)
+	case reflect.String:
+		s := reflect.ValueOf(value).String()
+		valueSystem.stringAsValue(target, s)
+	default:
+		alias = false
+	}
+	if alias {
+		return nil
+	}
+
+	// try nested types
+	switch vtype.Kind() {
+	case reflect.Ptr:
+		ptr := reflect.ValueOf(value)
+		if ptr.IsNil() {
+			return valueSystem.valueAsConnector(target, nil)
+		} else {
+			return valueSystem.valueAsConnector(target, ptr.Elem().Interface())
+		}
+	case reflect.Slice:
+		return valueSystem.listAsValue(target, value)
+	case reflect.Map:
+		return valueSystem.mapAsValue(target, value)
+	}
+
+	// ask for value handlers
+	if handler, ok := valueSystem.valueHandlersByType[vtype]; ok {
+		signature, fields, err := handler.Write(value)
+		if err != nil {
+			return err
 		}
 
-		if !handled {
-			v := reflect.TypeOf(value)
-
-			handled = true
-			switch v.Kind() {
-			case reflect.Ptr:
-				ptrv := reflect.ValueOf(value)
-				if ptrv.IsNil() {
-					C.BoltValue_format_as_Null(target)
-				} else {
-					valueSystem.valueAsConnector(target, ptrv.Elem().Interface())
-				}
-			case reflect.Slice:
-				valueSystem.listAsValue(target, value)
-			case reflect.Map:
-				valueSystem.mapAsValue(target, value)
-			default:
-				// ask for value handlers
-				if handler, ok := valueSystem.valueHandlersByType[v]; ok {
-					signature, fields, err := handler.Write(value)
-					if err != nil {
-						return err
-					}
-
-					C.BoltValue_format_as_Structure(target, C.int16_t(signature), C.int32_t(len(fields)))
-					for index, fieldValue := range fields {
-						valueSystem.valueAsConnector(C.BoltStructure_value(target, C.int32_t(index)), fieldValue)
-					}
-				} else {
-					handled = false
-				}
+		C.BoltValue_format_as_Structure(target, C.int16_t(signature), C.int32_t(len(fields)))
+		for index, fieldValue := range fields {
+			t := C.BoltStructure_value(target, C.int32_t(index))
+			if err := valueSystem.valueAsConnector(t, fieldValue); err != nil {
+				return err
 			}
 		}
 
-		if !handled {
-			return newGenericError("unsupported value for conversion: %v", value)
-		}
+		// custom handler ok
+		return nil
 	}
 
-	return nil
+	// nothing worked
+	return newGenericError("unsupported value for conversion: %v", value)
 }
 
 func (valueSystem *boltValueSystem) boolAsValue(target *C.struct_BoltValue, value bool) {
@@ -277,7 +304,9 @@ func (valueSystem *boltValueSystem) listAsValue(target *C.struct_BoltValue, valu
 	C.BoltValue_format_as_List(target, C.int32_t(slice.Len()))
 	for i := 0; i < slice.Len(); i++ {
 		elTarget := C.BoltList_value(target, C.int32_t(i))
-		valueSystem.valueAsConnector(elTarget, slice.Index(i).Interface())
+		if err := valueSystem.valueAsConnector(elTarget, slice.Index(i).Interface()); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -296,8 +325,12 @@ func (valueSystem *boltValueSystem) mapAsValue(target *C.struct_BoltValue, value
 		keyTarget := C.BoltDictionary_key(target, index)
 		elTarget := C.BoltDictionary_value(target, index)
 
-		valueSystem.valueAsConnector(keyTarget, key.Interface())
-		valueSystem.valueAsConnector(elTarget, dict.MapIndex(key).Interface())
+		if err := valueSystem.valueAsConnector(keyTarget, key.Interface()); err != nil {
+			return err
+		}
+		if err := valueSystem.valueAsConnector(elTarget, dict.MapIndex(key).Interface()); err != nil {
+			return err
+		}
 
 		index++
 	}

--- a/value.go
+++ b/value.go
@@ -262,7 +262,7 @@ func (valueSystem *boltValueSystem) valueAsConnector(target *C.struct_BoltValue,
 	}
 
 	// nothing worked
-	return newGenericError("unsupported value for conversion: %v", value)
+	return valueSystem.genericErrorFactory("unsupported value for conversion: %v", value)
 }
 
 func (valueSystem *boltValueSystem) boolAsValue(target *C.struct_BoltValue, value bool) {


### PR DESCRIPTION
Two issues handled here:

- Type aliases:
Currently, type-aliased parameters , i.e. `type MyString string` are not caught by the type switch in `value.go`, and fail as an unhandled type.  
One way to deal with aliased types is in the following switch on `reflect.Value.Kind`, since `MyString`'s `Kind` is still `reflect.String`. Same goes for all other basic types.

- Hidden errors:
A few methods swallow errors, specifically `listAsValue` and `mapAsValue` - which causes the previous errors to be hidden from the user - this made it pretty hard to understand what was happening with the type alias error.
Changed the methods in `value.go` to propagate all errors, and handle them in a similar way to before (in `connection.go:182`).

Also made some changes to the nesting if/else in `valueAsConnector` as it was getting pretty confusing (multiple returns now). If you prefer a single return I guess it can be changed back.